### PR TITLE
#35 - 태그 기반 관광지 조회

### DIFF
--- a/src/main/java/com/teamb/travel/controller/TourListController.java
+++ b/src/main/java/com/teamb/travel/controller/TourListController.java
@@ -2,6 +2,7 @@ package com.teamb.travel.controller;
 
 
 import com.teamb.travel.dto.PlaceByLocationResDto;
+import com.teamb.travel.dto.PlaceByTagResDto;
 import com.teamb.travel.service.PlaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +22,12 @@ public class TourListController {
     @GetMapping("/tourlist/location")
     public ResponseEntity<List<PlaceByLocationResDto>> tourListByLocation(@RequestParam("pageno") int pageNo, @RequestParam("areacode") String areaCode) {
         List<PlaceByLocationResDto> resDtos = placeService.selectByLocationPlaceList(areaCode, pageNo);
+        return new ResponseEntity<>(resDtos, HttpStatus.OK);
+    }
+
+    @GetMapping("/tourlist/hashtag")
+    public ResponseEntity<List<PlaceByTagResDto>> tourListByLocation(@RequestParam("pageno") int pageNo, @RequestParam("hashtag") List<String> hashtag) {
+        List<PlaceByTagResDto> resDtos = placeService.selectByTagPlaceList(hashtag, pageNo);
         return new ResponseEntity<>(resDtos, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/teamb/travel/dto/PlaceByTagResDto.java
+++ b/src/main/java/com/teamb/travel/dto/PlaceByTagResDto.java
@@ -1,0 +1,35 @@
+package com.teamb.travel.dto;
+
+import com.teamb.travel.entity.IsIndoor;
+import com.teamb.travel.entity.Place;
+import com.teamb.travel.entity.PlaceDetail;
+import com.teamb.travel.entity.Reply;
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+public class PlaceByTagResDto {
+    private String addr1;
+    private String contentid;
+    private String title;
+    private String cat3;
+    private String infocenter;
+    private String firstimage;
+    private String inOut;
+    private Double rate;
+
+    public PlaceByTagResDto (Place place, PlaceDetail placeDetail, IsIndoor indoor, Reply reply) {
+        this.addr1 = place.getAddr1();
+        this.contentid = place.getContentid();
+        this.title = place.getTitle();
+        this.cat3 = place.getCat3();
+        this.infocenter = placeDetail.getInfocenter();
+        this.firstimage = place.getFirstimage();
+        this.inOut = indoor.getInOut();
+        this.rate = reply.getRate();
+    }
+}

--- a/src/main/java/com/teamb/travel/repository/PlaceRepository.java
+++ b/src/main/java/com/teamb/travel/repository/PlaceRepository.java
@@ -14,4 +14,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     nativeQuery = true)
     public List<String> findByAllContentid();
     public List<Place> findAllByAreacodeOrderByIdAsc(String areaCode, Pageable pageable);
+
+    public List<Place> findAllByCat3InOrderByIdAsc(List<String> hashtag, Pageable pageable);
 }

--- a/src/main/java/com/teamb/travel/service/PlaceService.java
+++ b/src/main/java/com/teamb/travel/service/PlaceService.java
@@ -1,6 +1,7 @@
 package com.teamb.travel.service;
 
 import com.teamb.travel.dto.PlaceByLocationResDto;
+import com.teamb.travel.dto.PlaceByTagResDto;
 import com.teamb.travel.entity.IsIndoor;
 import com.teamb.travel.entity.Place;
 import com.teamb.travel.entity.PlaceDetail;
@@ -31,11 +32,11 @@ public class PlaceService {
     }
 
     public List<PlaceByLocationResDto> selectByLocationPlaceList(String areaCode, int pageNo) {
+        List<PlaceByLocationResDto> resDtos = new ArrayList<>();
         List<Double> result = new ArrayList<>();
         List<String> inOut = new ArrayList<>();
         List<String> mapX = new ArrayList<>();
         List<String> mapY = new ArrayList<>();
-        List<PlaceByLocationResDto> resDtos = new ArrayList<>();
 
         Pageable pageable = PageRequest.of(pageNo-1, 12);
         List<Place> places = repository.findAllByAreacodeOrderByIdAsc(areaCode, pageable);
@@ -43,23 +44,7 @@ public class PlaceService {
         List<PlaceDetail> detailList = detailRepository.findAllByContentidIn(contentid);
 
         for (int i = 0; i < contentid.size(); i++) {
-            mapX.add(places.get(i).getMapx().substring(0, 7));
-            mapY.add(places.get(i).getMapy().substring(0, 6));
-
-            Double rates = replyRepository.findByPlaceDetailInNativeQuery(contentid.get(i));
-            if (rates == null) {
-                result.add(i, 0.0);
-            } else {
-                result.add(i, rates);
-            }
-
-            IsIndoor indoors = indoorRepository.findAllByMapXAndMapY(mapX.get(i), mapY.get(i));
-
-            if (indoors == null) {
-                inOut.add(i, "");
-            } else {
-                inOut.add(i, indoors.getInOut());
-            }
+            mapping(result, inOut, mapX, mapY, places, contentid, i);
 
             PlaceByLocationResDto dto = PlaceByLocationResDto.builder().addr1(places.get(i).getAddr1()).contentid(places.get(i).getContentid())
                     .title(places.get(i).getTitle()).cat3(places.get(i).getCat3())
@@ -70,5 +55,51 @@ public class PlaceService {
         }
 
         return resDtos;
+    }
+
+    public List<PlaceByTagResDto> selectByTagPlaceList(List<String> hashtag, int pageNo) {
+        List<PlaceByTagResDto> resDtos = new ArrayList<>();
+        List<Double> result = new ArrayList<>();
+        List<String> inOut = new ArrayList<>();
+        List<String> mapX = new ArrayList<>();
+        List<String> mapY = new ArrayList<>();
+
+        Pageable pageable = PageRequest.of(pageNo-1, 12);
+        List<Place> places = repository.findAllByCat3InOrderByIdAsc(hashtag, pageable);
+        List<String> contentid = places.stream().map(Place::getContentid).collect(Collectors.toList());
+        List<PlaceDetail> detailList = detailRepository.findAllByContentidIn(contentid);
+
+        for (int i = 0; i < contentid.size(); i++) {
+            mapping(result, inOut, mapX, mapY, places, contentid, i);
+
+            PlaceByTagResDto dto = PlaceByTagResDto.builder().addr1(places.get(i).getAddr1()).contentid(places.get(i).getContentid())
+                    .title(places.get(i).getTitle()).cat3(places.get(i).getCat3())
+                    .infocenter(detailList.get(i).getInfocenter()).firstimage(places.get(i).getFirstimage())
+                    .inOut(inOut.get(i)).rate(result.get(i)).build();
+
+            resDtos.add(dto);
+        }
+
+        return resDtos;
+    }
+
+    private void mapping(List<Double> result, List<String> inOut, List<String> mapX, List<String> mapY, List<Place> places, List<String> contentid, int i) {
+        mapX.add(places.get(i).getMapx().substring(0, 7));
+        mapY.add(places.get(i).getMapy().substring(0, 6));
+
+        Double rates = replyRepository.findByPlaceDetailInNativeQuery(contentid.get(i));
+        if (rates == null) {
+            result.add(i, 0.0);
+        } else {
+            result.add(i, rates);
+        }
+
+        IsIndoor indoors = indoorRepository.findAllByMapXAndMapY(mapX.get(i), mapY.get(i));
+
+        if (indoors == null) {
+            inOut.add(i, "");
+        } else {
+            inOut.add(i, indoors.getInOut());
+        }
     }
 }


### PR DESCRIPTION
close #35 

- [ ] pageNo, hashtag를 토대로 관광지 리스트 조회(한페이지 당 관광지 수는 12개), hashtag는 리스트를 통해 다수의 값을 전달 받을 수 있다.
- [ ] 해당 관광지의 리뷰가 없어 평점 값이 없다면 0.0 출력
- [ ] 실내외 여부 파악이 불가능하면 ""으로 빈 값 출력
 