### PR TITLE
#76 - API Https 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,4 +220,5 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 application-profile.properties
+keystore.jks
 # End of https://www.toptal.com/developers/gitignore/api/java,intellij+all,gradle,windows,macos,visualstudiocode

--- a/src/main/java/com/teamb/travel/TeamBBeApplication.java
+++ b/src/main/java/com/teamb/travel/TeamBBeApplication.java
@@ -1,13 +1,32 @@
 package com.teamb.travel;
 
+import org.apache.catalina.connector.Connector;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class TeamBBeApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(TeamBBeApplication.class, args);
+    }
+
+    @Bean
+    public ServletWebServerFactory serverFactory() {
+        TomcatServletWebServerFactory tomcatServletWebServerFactory
+                = new TomcatServletWebServerFactory();
+        tomcatServletWebServerFactory.addAdditionalTomcatConnectors(createStandardConnector());
+
+        return tomcatServletWebServerFactory;
+    }
+
+    private Connector createStandardConnector() { // http : 80
+        Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+        connector.setPort(80);
+        return connector;
     }
 
 }


### PR DESCRIPTION
https://github.com/fastcampus-febe/TeamB-BE/issues/76 [- .gitignore에 SSL 증명서 파일 이름 추가](https://github.com/fastcampus-febe/TeamB-BE/commit/76eeb643544cbfff24b4ef61e80cca077106dd94) 

- SSL 증명서가 remote에 올라가지 않도록 .gitignore에 추가
- 참고 : https://kimjongmo.github.io/spring/spring-boot-https

https://github.com/fastcampus-febe/TeamB-BE/issues/76 [- https 설정 추가](https://github.com/fastcampus-febe/TeamB-BE/commit/1dbca0b14a14d8b72a1d9e64e124da26b22eefd4)