### PR TITLE
#79 - 배포 전 build.gradle에서 안쓰는 의존성 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,17 +19,13 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
 
     //JSON
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'

--- a/src/main/java/com/teamb/travel/config/SwaggerConfig.java
+++ b/src/main/java/com/teamb/travel/config/SwaggerConfig.java
@@ -1,17 +1,7 @@
 package com.teamb.travel.config;
 
-import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
-import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
-import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
-import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
-import org.springframework.boot.actuate.endpoint.web.*;
-import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
-import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
-import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
-import org.springframework.util.StringUtils;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -20,9 +10,6 @@ import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 @Configuration
 @EnableSwagger2
@@ -50,26 +37,4 @@ public class SwaggerConfig {
                 .build();
     }
 
-    @Bean
-    public WebMvcEndpointHandlerMapping webEndpointServletHandlerMapping
-            (WebEndpointsSupplier webEndpointsSupplier, ServletEndpointsSupplier servletEndpointsSupplier,
-             ControllerEndpointsSupplier controllerEndpointsSupplier, EndpointMediaTypes endpointMediaTypes,
-             CorsEndpointProperties corsProperties, WebEndpointProperties webEndpointProperties, Environment environment) {
-
-        List<ExposableEndpoint<?>> allEndpoints = new ArrayList<>();
-        Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
-        allEndpoints.addAll(webEndpoints);
-        allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());
-        allEndpoints.addAll(controllerEndpointsSupplier.getEndpoints());
-        String basePath = webEndpointProperties.getBasePath();
-        EndpointMapping endpointMapping = new EndpointMapping(basePath);
-        boolean shouldRegisterLinksMapping = this.shouldRegisterLinksMapping(webEndpointProperties, environment, basePath);
-
-        return new WebMvcEndpointHandlerMapping(endpointMapping, webEndpoints, endpointMediaTypes, corsProperties.toCorsConfiguration(),
-                new EndpointLinksResolver(allEndpoints, basePath), shouldRegisterLinksMapping, null);
-    }
-
-    private boolean shouldRegisterLinksMapping(WebEndpointProperties webEndpointProperties, Environment environment, String basePath) {
-        return webEndpointProperties.getDiscovery().isEnabled() && (StringUtils.hasText(basePath) || ManagementPortType.get(environment).equals(ManagementPortType.DIFFERENT));
-    }
 }


### PR DESCRIPTION
https://github.com/fastcampus-febe/TeamB-BE/issues/79 [- build.gradle에서 안쓰는 의존성 삭제](https://github.com/fastcampus-febe/TeamB-BE/commit/0961ea6cde7f802789844e59c3c2e83bc6bad9cf) 

- 배포 시 문제될 수 있어 안쓰는 의존성은 삭제함

https://github.com/fastcampus-febe/TeamB-BE/issues/79 [- 의존성 삭제하면서 필요없어진 코드 삭제](https://github.com/fastcampus-febe/TeamB-BE/commit/36b7975d39f313e8794ad366f366cac2701cfd49) 

- spring-boot-starter-actuator 때문에 추가했었던 코드인데, actuator 의존성에서 삭제함에 따라 이 코드도 삭제함